### PR TITLE
preDelete method

### DIFF
--- a/src/main/java/eu/freme/common/rest/OwnedResourceManagingController.java
+++ b/src/main/java/eu/freme/common/rest/OwnedResourceManagingController.java
@@ -76,9 +76,7 @@ public abstract class OwnedResourceManagingController<Entity extends OwnedResour
      */
     protected abstract void updateEntity(Entity entity, String body, Map<String, String> parameters, Map<String, String> headers) throws BadRequestException;
 
-    protected void preDelete(Entity entity){
-        // empty
-    }
+    protected abstract preDelete(Entity entity);
 
     public OwnedResourceDAO<Entity> getEntityDAO() {
         return entityDAO;


### PR DESCRIPTION
When you try to delete a dataset from FREME-NER, the dataset is removed from MySQL properly, but not from Solr.  This bug was reported [here](https://github.com/freme-project/freme-ner/issues/145). 

It happens because the preDelete runs locally and  is never called in [FREME-NER](https://github.com/freme-project/freme-ner/blob/master/src/main/java/org/elinker/core/rest/FremeNerManageDatasets.java#L155) 
